### PR TITLE
Remove unnecessary .profile edit suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ Add a `source` command at the end:
 
     cp symfony2-autocomplete.bash /etc/bash_completion.d/
 
-Add the following line to your `~/.bashrc` or `.bash_profile`:
-
-    if [ -e ~/symfony2-autocomplete.bash ]; then
-        . ~/symfony2-autocomplete.bash
-    fi
-
 Restart your bash and you should be able to autocomplete in a Symfony2 project:
 
     ./app/console doc[TAB]


### PR DESCRIPTION
any files in /etc/bash_completion.d/ are loaded automatically

The suggested edit to your profile is irrelevant as nowhere in the instructions does it say "copy this file also to your home dir" - so the test for whether `~/symfony2-autocomplete.bash` exists will always be false.
