### PR TITLE
Reverted previous merge as it introduces regressions

### DIFF
--- a/symfony2-autocomplete.bash
+++ b/symfony2-autocomplete.bash
@@ -7,24 +7,48 @@
 
 _console()
 {
-    local cur prev cmd
+    local cur prev script
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    cmd="${COMP_WORDS[0]}"
-    PHP='$ret = shell_exec($argv[1] . " --no-debug --env=prod");
+    script="${COMP_WORDS[0]}"
 
-$comps = "";
-$ret = preg_replace("/^.*Available commands:\n/s", "", $ret);
-if (preg_match_all("@^  ([^ ]+) @m", $ret, $m)) {
-    $comps = $m[1];
+    if [[ ${cur} == -* ]] ; then
+        PHP=$(cat <<'HEREDOC'
+array_shift($argv);
+$script = array_shift($argv);
+$command = '';
+foreach ($argv as $v) {
+    if (0 !== strpos($v, '-')) {
+        $command = $v;
+        break;
+    }
 }
 
-echo implode("\n", $comps);
-'
-    possible=$($(which php) -r "$PHP" $COMP_WORDS);
-    COMPREPLY=( $(compgen -W "${possible}" -- ${cur}) )
-    return 0
+$xmlHelp = shell_exec($script.' help --xml '.$command);
+$options = array();
+if (!$xml = @simplexml_load_string($xmlHelp)) {
+    exit(0);
+}
+foreach ($xml->xpath('/command/options/option') as $option) {
+    $options[] = (string) $option['name'];
+}
+
+echo implode(' ', $options);
+HEREDOC
+)
+
+        args=$(printf "%s " "${COMP_WORDS[@]}")
+        options=$($(which php) -r "$PHP" ${args});
+        COMPREPLY=($(compgen -W "${options}" -- ${cur}))
+
+        return 0
+    fi
+
+    commands=$(${script} list --raw | sed -E 's/(([^ ]+ )).*/\1/')
+    COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+
+    return 0;
 }
 
 complete -F _console console


### PR DESCRIPTION
I think #14 should be reverted, it introduces regressions : 
- command options completion is not supported anymore
- commands registered in dev environment are gone (eg. generate:bundle)
